### PR TITLE
fix(#TYP-69): Refactor db interactions

### DIFF
--- a/.github/spellcheck/dictionaries/project-words.txt
+++ b/.github/spellcheck/dictionaries/project-words.txt
@@ -13,6 +13,7 @@ QWERTZ
 scancode
 scancodes
 vexpand
+gsignals
 
 # Build
 bindir

--- a/typetrace/application.py
+++ b/typetrace/application.py
@@ -40,7 +40,12 @@ class Application(Adw.Application):
         """
         win = self.props.active_window
         if not win:
-            win = TypetraceWindow(self.keystroke_store, self.settings, application=self)
+            win = TypetraceWindow(
+                self.db_manager,
+                self.keystroke_store,
+                self.settings,
+                application=self,
+            )
         win.present()
 
     def do_shutdown(self) -> None:

--- a/typetrace/application.py
+++ b/typetrace/application.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import sqlite3
 from typing import Any, Callable
 
 from gi.repository import Adw, Gio
 
+from typetrace.config import DatabasePath
 from typetrace.controller.preferences import Preferences
 from typetrace.controller.window import TypetraceWindow
 from typetrace.model.database_manager import DatabaseManager
@@ -25,7 +27,8 @@ class Application(Adw.Application):
         self.version = version
         self.settings = Gio.Settings.new("edu.ost.typetrace")
 
-        self.keystroke_store = KeystrokeStore()
+        self.db_conn = sqlite3.connect(DatabasePath.DB_PATH)
+        self.keystroke_store = KeystrokeStore(self.db_conn)
         self.db_manager = DatabaseManager()
 
         self._setup_actions()
@@ -39,6 +42,11 @@ class Application(Adw.Application):
         if not win:
             win = TypetraceWindow(self.keystroke_store, self.settings, application=self)
         win.present()
+
+    def do_shutdown(self) -> None:
+        """Clean up resources when the application shuts down."""
+        self.db_conn.close()
+        Gio.Application.do_shutdown(self)
 
     def _setup_actions(self) -> None:
         """Set up application actions and their shortcuts."""

--- a/typetrace/controller/heatmap.py
+++ b/typetrace/controller/heatmap.py
@@ -10,7 +10,7 @@ from typetrace.controller.utils.color_utils import get_color_scheme
 from typetrace.model.layouts import KEYBOARD_LAYOUTS
 
 if TYPE_CHECKING:
-    from typetrace.model.keystrokes import KeystrokeStore
+    from typetrace.model.keystrokes import Keystroke, KeystrokeStore
 
 
 @Gtk.Template(resource_path="/edu/ost/typetrace/view/heatmap.ui")
@@ -80,9 +80,9 @@ class Heatmap(Gtk.Box):
         self._build_keyboard()
         self._update_colors()
 
-    def update(self) -> None:
+    def update(self, keystrokes: list[Keystroke] | None = None) -> None:
         """Update the heatmap to reflect current data."""
-        self._update_colors()
+        self._update_colors(keystrokes)
 
     def _build_keyboard(self) -> None:
         """Build the keyboard layout dynamically using scancodes."""
@@ -109,9 +109,10 @@ class Heatmap(Gtk.Box):
         label.set_size_request(size, size)
         return label
 
-    def _update_colors(self) -> None:
+    def _update_colors(self, keystrokes: list[Keystroke] | None = None) -> None:
         """Assign each displayed key the appropriate color."""
-        keystrokes = self.keystroke_store.get_all_keystrokes()
+        if keystrokes is None:
+            keystrokes = self.keystroke_store.get_all_keystrokes()
         most_pressed = self.keystroke_store.get_highest_count() or 1
 
         color_scheme = get_color_scheme(self.settings)

--- a/typetrace/controller/verbose.py
+++ b/typetrace/controller/verbose.py
@@ -1,4 +1,5 @@
 """The verbose widget that displays keystroke data in text."""
+from __future__ import annotations
 
 from gi.repository import Gio, Gtk
 
@@ -34,14 +35,16 @@ class Verbose(Gtk.Box):
         # Set the sort_model's sorter to the column_view's sorter
         self.sort_model.set_sorter(self.column_view.get_sorter())
 
-    def update(self) -> None:
+    def update(self, keystrokes: list[Keystroke] | None = None) -> None:
         """Update the list to reflect current data."""
-        self._populate_list_store()
+        self._populate_list_store(keystrokes)
 
-    def _populate_list_store(self) -> None:
+    def _populate_list_store(self, keystrokes: list[Keystroke] | None = None) -> None:
         """Populate the list store with keystroke data."""
+        if keystrokes is None:
+            keystrokes = self.keystroke_store.get_all_keystrokes()
         self.list_store.remove_all()
-        for keystroke in self.keystroke_store.get_all_keystrokes():
+        for keystroke in keystrokes:
             self.list_store.append(
                 Keystroke(
                     scan_code=keystroke.scan_code,

--- a/typetrace/controller/window.py
+++ b/typetrace/controller/window.py
@@ -5,6 +5,7 @@ from gi.repository import Adw, Gio, Gtk
 from typetrace.controller.heatmap import Heatmap
 from typetrace.controller.statistics import Statistics
 from typetrace.controller.verbose import Verbose
+from typetrace.model.database_manager import DatabaseManager
 from typetrace.model.keystrokes import KeystrokeStore
 
 
@@ -23,6 +24,7 @@ class TypetraceWindow(Adw.ApplicationWindow):
 
     def __init__(
         self,
+        db_manager: DatabaseManager,
         keystroke_store: KeystrokeStore,
         settings: Gio.Settings,
         **kwargs,
@@ -31,16 +33,20 @@ class TypetraceWindow(Adw.ApplicationWindow):
 
         Args:
             **kwargs: Keyword arguments passed to the parent constructor
+            db_manager: DB File operations
             keystroke_store: Access to keystrokes
             settings: GSettings used to persist preferences of a user
 
         """
         super().__init__(**kwargs)
+        self.db_manager = db_manager
         self.keystroke_store = keystroke_store
         self.heatmap = Heatmap(keystroke_store=keystroke_store, settings=settings)
         self.verbose = Verbose(keystroke_store=keystroke_store)
         self.statistics = Statistics(keystroke_store=keystroke_store)
         self.refresh_button.connect("clicked", lambda *_: self._on_refresh_clicked())
+        self.keystroke_store.connect("changed", lambda *_: self._on_refresh_clicked())
+        self.db_manager.connect("changed", lambda *_: self._on_refresh_clicked())
 
         heatmap_page = self.stack.add_titled(
             self.heatmap,

--- a/typetrace/controller/window.py
+++ b/typetrace/controller/window.py
@@ -36,6 +36,7 @@ class TypetraceWindow(Adw.ApplicationWindow):
 
         """
         super().__init__(**kwargs)
+        self.keystroke_store = keystroke_store
         self.heatmap = Heatmap(keystroke_store=keystroke_store, settings=settings)
         self.verbose = Verbose(keystroke_store=keystroke_store)
         self.statistics = Statistics(keystroke_store=keystroke_store)
@@ -63,6 +64,7 @@ class TypetraceWindow(Adw.ApplicationWindow):
 
     def _on_refresh_clicked(self) -> None:
         """Handle refresh button click."""
-        self.heatmap.update()
-        self.verbose.update()
+        keystrokes = self.keystroke_store.get_all_keystrokes()
+        self.heatmap.update(keystrokes)
+        self.verbose.update(keystrokes)
         self.statistics.update()

--- a/typetrace/controller/window.py
+++ b/typetrace/controller/window.py
@@ -65,7 +65,7 @@ class TypetraceWindow(Adw.ApplicationWindow):
             "statistics",
             "Statistics",
         )
-        statistics_page.set_icon_name("image-filter-symbolic")
+        statistics_page.set_icon_name("view-grid-symbolic")
         self.view_switcher.set_stack(self.stack)
 
     def _on_refresh_clicked(self) -> None:

--- a/typetrace/model/database_manager.py
+++ b/typetrace/model/database_manager.py
@@ -2,7 +2,7 @@
 
 import shutil
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from gi.repository import GObject
 
@@ -17,7 +17,7 @@ class DatabaseManager(GObject.Object):
         super().__init__()
         self.db_path = Path(DatabasePath.DB_PATH)
 
-    __gsignals__: ClassVar[Any] = {
+    __gsignals__: ClassVar[dict] = {
         "changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 

--- a/typetrace/model/database_manager.py
+++ b/typetrace/model/database_manager.py
@@ -2,6 +2,7 @@
 
 import shutil
 from pathlib import Path
+from typing import Any, ClassVar
 
 from gi.repository import GObject
 
@@ -16,7 +17,7 @@ class DatabaseManager(GObject.Object):
         super().__init__()
         self.db_path = Path(DatabasePath.DB_PATH)
 
-    __gsignals__ = {  # noqa: RUF012
+    __gsignals__: ClassVar[Any] = {
         "changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 

--- a/typetrace/model/database_manager.py
+++ b/typetrace/model/database_manager.py
@@ -3,15 +3,22 @@
 import shutil
 from pathlib import Path
 
+from gi.repository import GObject
+
 from typetrace.config import DatabasePath
 
 
-class DatabaseManager:
+class DatabaseManager(GObject.Object):
     """Used for manipulations concerning the database file."""
 
     def __init__(self) -> None:
         """Construct an instance of DatabaseManager."""
+        super().__init__()
         self.db_path = Path(DatabasePath.DB_PATH)
+
+    __gsignals__ = {  # noqa: RUF012
+        "changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
+    }
 
     def export_database(self, dest_path: Path) -> bool:
         """Export the database to the specified destination path."""
@@ -30,4 +37,5 @@ class DatabaseManager:
         except OSError:
             return False
         else:
+            self.emit("changed")
             return True

--- a/typetrace/model/keystrokes.py
+++ b/typetrace/model/keystrokes.py
@@ -32,9 +32,10 @@ class Keystroke(GObject.Object):
 class KeystrokeStore:
     """Model for interacting with the keystrokes table in the database."""
 
-    def __init__(self) -> None:
+    def __init__(self, conn: sqlite3.Connection) -> None:
         """Initialize the model with the database path."""
         self.db_path = DatabasePath.DB_PATH
+        self.conn = conn
 
     def get_all_keystrokes(self) -> list[Keystroke]:
         """Retrieve all keystrokes with their counts and names.
@@ -42,45 +43,42 @@ class KeystrokeStore:
         Returns aggregated data across all dates.
         """
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.cursor()
-                cursor.execute(SQLQueries.GET_ALL_KEYSTROKES)
-                rows = cursor.fetchall()
-
-                # Convert rows to Keystroke objects
-                return [
-                    Keystroke(
-                        scan_code=row[0],
-                        count=row[1],
-                        key_name=row[2],
-                        date=row[3],
-                    )
-                    for row in rows
-                ]
+            cursor = self.conn.cursor()
+            cursor.execute(SQLQueries.GET_ALL_KEYSTROKES)
+            rows = cursor.fetchall()
+            return [
+                Keystroke(
+                    scan_code=row[0],
+                    count=row[1],
+                    key_name=row[2],
+                    date=row[3],
+                )
+                for row in rows
+            ]
         except sqlite3.Error:
             return []
 
     def get_total_presses(self) -> int:
         """Get the total number of key presses across all keystrokes and all dates."""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.cursor()
-                cursor.execute(SQLQueries.GET_TOTAL_PRESSES)
-                result = cursor.fetchone()[0]
-                return result if result is not None else 0
+            cursor = self.conn.cursor()
+            cursor.execute(SQLQueries.GET_TOTAL_PRESSES)
+            result = cursor.fetchone()[0]
         except sqlite3.Error:
             return 0
+        else:
+            return result or 0
 
     def get_highest_count(self) -> int:
         """Retrieve the highest total count of any keystroke across all dates."""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.cursor()
-                cursor.execute(SQLQueries.GET_HIGHEST_COUNT)
-                result = cursor.fetchone()[0]
-                return result if result is not None else 0
+            cursor = self.conn.cursor()
+            cursor.execute(SQLQueries.GET_HIGHEST_COUNT)
+            result = cursor.fetchone()[0]
         except sqlite3.Error:
             return 0
+        else:
+            return result or 0
 
     def get_keystrokes_by_date(self, date: str) -> list[Keystroke]:
         """Retrieve keystrokes for a specific date.
@@ -93,40 +91,32 @@ class KeystrokeStore:
 
         """
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    SQLQueries.GET_KEYSTROKES_BY_DATE,
-                    (date,),
+            cursor = self.conn.cursor()
+            cursor.execute(SQLQueries.GET_KEYSTROKES_BY_DATE, (date,))
+            rows = cursor.fetchall()
+            return [
+                Keystroke(
+                    scan_code=row[0],
+                    count=row[1],
+                    key_name=row[2],
+                    date=row[3],
                 )
-                rows = cursor.fetchall()
-
-                # Convert rows to Keystroke objects
-                return [
-                    Keystroke(
-                        scan_code=row[0],
-                        count=row[1],
-                        key_name=row[2],
-                        date=row[3],
-                    )
-                    for row in rows
-                ]
+                for row in rows
+            ]
         except sqlite3.Error:
             return []
 
     def clear(self) -> bool:
         """Remove all entries."""
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.cursor()
-                cursor.execute(SQLQueries.CLEAR_KEYSTROKES)
-                conn.commit()
+            cursor = self.conn.cursor()
+            cursor.execute(SQLQueries.CLEAR_KEYSTROKES)
+            self.conn.commit()
         except sqlite3.Error:
             return False
         else:
             return True
 
-    # Note: refactor every 'with' in this file to only use one connection
     def get_daily_keystroke_counts(self) -> list[dict]:
         """Get daily keystroke counts for the past 7 days.
 
@@ -135,17 +125,15 @@ class KeystrokeStore:
 
         """
         try:
-            with sqlite3.connect(self.db_path) as conn:
-                cursor = conn.cursor()
-                cursor.execute(SQLQueries.GET_DAILY_KEYSTROKE_COUNTS)
-                rows = cursor.fetchall()
-
-                return [
-                    {
-                        "date": row[0],
-                        "count": row[1],
-                    }
-                    for row in rows
-                ]
+            cursor = self.conn.cursor()
+            cursor.execute(SQLQueries.GET_DAILY_KEYSTROKE_COUNTS)
+            rows = cursor.fetchall()
+            return [
+                {
+                    "date": row[0],
+                    "count": row[1],
+                }
+                for row in rows
+            ]
         except sqlite3.Error:
             return []

--- a/typetrace/model/keystrokes.py
+++ b/typetrace/model/keystrokes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from gi.repository import GObject
 
@@ -39,7 +39,7 @@ class KeystrokeStore(GObject.Object):
         self.db_path = DatabasePath.DB_PATH
         self.conn = conn
 
-    __gsignals__: ClassVar[Any] = {
+    __gsignals__: ClassVar[dict] = {
         "changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 

--- a/typetrace/model/keystrokes.py
+++ b/typetrace/model/keystrokes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from typing import Any, ClassVar
 
 from gi.repository import GObject
 
@@ -38,7 +39,7 @@ class KeystrokeStore(GObject.Object):
         self.db_path = DatabasePath.DB_PATH
         self.conn = conn
 
-    __gsignals__ = {  # noqa: RUF012
+    __gsignals__: ClassVar[Any] = {
         "changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 

--- a/typetrace/model/keystrokes.py
+++ b/typetrace/model/keystrokes.py
@@ -29,13 +29,18 @@ class Keystroke(GObject.Object):
         self.date = date
 
 
-class KeystrokeStore:
+class KeystrokeStore(GObject.Object):
     """Model for interacting with the keystrokes table in the database."""
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         """Initialize the model with the database path."""
+        super().__init__()
         self.db_path = DatabasePath.DB_PATH
         self.conn = conn
+
+    __gsignals__ = {  # noqa: RUF012
+        "changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
+    }
 
     def get_all_keystrokes(self) -> list[Keystroke]:
         """Retrieve all keystrokes with their counts and names.
@@ -112,6 +117,7 @@ class KeystrokeStore:
             cursor = self.conn.cursor()
             cursor.execute(SQLQueries.CLEAR_KEYSTROKES)
             self.conn.commit()
+            self.emit("changed")
         except sqlite3.Error:
             return False
         else:

--- a/typetrace/view/window.blp
+++ b/typetrace/view/window.blp
@@ -3,8 +3,6 @@ using Adw 1;
 
 template $TypetraceWindow: Adw.ApplicationWindow {
   title: "TypeTrace";
-  default-width: 1060;
-  default-height: 530;
 
   content: Adw.ToolbarView {
     [top]


### PR DESCRIPTION
- Make it so get_all_keys isn't called more often than necessary
- Create connection at higher level
- Certain operation like import and clear should refresh view directly through signals